### PR TITLE
word wrap for multiline Edit Box-win32 restored

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -115,7 +115,7 @@ namespace ui {
             _hwndEdit = ::CreateWindowExW(
                 WS_EX_CLIENTEDGE, L"EDIT",   // predefined class 
                 NULL,         // no window title 
-                WS_CHILD | ES_LEFT | WS_BORDER | WS_EX_TRANSPARENT | WS_TABSTOP | ES_AUTOHSCROLL | (singleLine ? 0 : ES_MULTILINE),
+                WS_CHILD | ES_LEFT | WS_BORDER | WS_EX_TRANSPARENT | WS_TABSTOP | (singleLine ? ES_AUTOHSCROLL : (ES_AUTOVSCROLL | ES_MULTILINE)),
                 0,
                 0,
                 0,


### PR DESCRIPTION
in commit 01ee30a023e18d word wrap for multiline ui::EditBox has been broken